### PR TITLE
feat: support extra MJCF joints and harden mesh processing

### DIFF
--- a/docs/en/METADATA_REFERENCE.md
+++ b/docs/en/METADATA_REFERENCE.md
@@ -25,6 +25,7 @@ Common fields:
 | `touch_sensors` | list | `[]` | Touch sensor definitions |
 | `collision_geometries` | list\|null | `null` | Custom collision geometry replacements |
 | `explicit_contacts` | object\|null | `null` | Explicit floor contact configuration |
+| `extra_joints` | list | `[]` | MJCF-only joints inserted into generated bodies |
 | `weld_constraints` | list | `[]` | Weld constraints (body locking) |
 | `remove_redundancies` | bool | `true` | Remove redundant elements |
 | `maxhullvert` | int\|null | `null` | Max hull vertices for collision |
@@ -46,6 +47,27 @@ Common fields:
 ### Collision Replacement Records
 
 - `CollisionGeometry`: `name`, `collision_type`, `sphere_radius`, `axis_order`, `flip_axis`, `offset_x`, `offset_y`, `offset_z`
+
+### Extra Joint Records
+
+`extra_joints` inserts MJCF joints that do not exist in the source URDF. Use `actuator.json` to add actuators for these joints by name.
+
+```json
+{
+  "extra_joints": [
+    {
+      "body_name": "base_link",
+      "name": "base_x",
+      "type": "slide",
+      "axis": [1, 0, 0],
+      "joint_class": "base_slide",
+      "range": [-1000, 1000]
+    }
+  ]
+}
+```
+
+Fields: `body_name`, `name`, `type`, `axis`, `joint_class`, `range`.
 
 ## `default.json`
 

--- a/docs/zh_CN/METADATA_REFERENCE.md
+++ b/docs/zh_CN/METADATA_REFERENCE.md
@@ -25,6 +25,7 @@
 | `touch_sensors` | list | `[]` | 触觉传感器定义 |
 | `collision_geometries` | list\|null | `null` | 自定义碰撞几何体替换 |
 | `explicit_contacts` | object\|null | `null` | 显式地面接触配置 |
+| `extra_joints` | list | `[]` | 插入到已生成 body 中的 MJCF-only 关节 |
 | `weld_constraints` | list | `[]` | 焊接约束（body 锁定） |
 | `remove_redundancies` | bool | `true` | 移除冗余元素 |
 | `maxhullvert` | int\|null | `null` | 碰撞凸包最大顶点数 |
@@ -46,6 +47,27 @@
 ### 碰撞替换记录
 
 - `CollisionGeometry`：`name`, `collision_type`, `sphere_radius`, `axis_order`, `flip_axis`, `offset_x`, `offset_y`, `offset_z`
+
+### 额外关节记录
+
+`extra_joints` 用于插入源 URDF 中不存在的 MJCF 关节。需要驱动这些关节时，在 `actuator.json` 中按关节名添加执行器配置。
+
+```json
+{
+  "extra_joints": [
+    {
+      "body_name": "base_link",
+      "name": "base_x",
+      "type": "slide",
+      "axis": [1, 0, 0],
+      "joint_class": "base_slide",
+      "range": [-1000, 1000]
+    }
+  ]
+}
+```
+
+字段：`body_name`, `name`, `type`, `axis`, `joint_class`, `range`。
 
 ## `default.json`
 

--- a/src/urdf_to_mjcf/conversion/body_builder.py
+++ b/src/urdf_to_mjcf/conversion/body_builder.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import re
 import xml.etree.ElementTree as ET
 from collections.abc import Mapping
 from pathlib import Path
 
 import numpy as np
 
+from urdf_to_mjcf.conversion.assets import resolve_mesh_source_path
 from urdf_to_mjcf.core.geometry import GeomElement, ParsedJointParams, rpy_to_quat
 from urdf_to_mjcf.core.materials import get_obj_material_info
 from urdf_to_mjcf.core.model import ActuatorMetadata
@@ -32,6 +35,76 @@ def build_robot_body_tree(
     """Build the MJCF body hierarchy for a URDF robot."""
 
     actuator_joints: list[ParsedJointParams] = []
+
+    mesh_key_by_name: dict[str, str] = {}
+    mesh_name_by_key: dict[str, str] = {}
+
+    def mesh_scale_key(scale: str | None) -> str:
+        if scale is None:
+            return ""
+        try:
+            values = tuple(float(value) for value in scale.split())
+        except ValueError:
+            return " ".join(scale.split())
+        if len(values) == 1:
+            values = (values[0], values[0], values[0])
+        if len(values) == 3:
+            return " ".join(f"{value:g}" for value in values)
+        return " ".join(scale.split())
+
+    def mesh_asset_key(filename: str, *, mode: str, scale: str | None) -> str:
+        source_path, sub_path = resolve_mesh_source_path(
+            filename,
+            urdf_dir=urdf_dir,
+            workspace_search_paths=workspace_search_paths,
+        )
+        if source_path is not None:
+            file_key = f"path:{source_path.expanduser().resolve(strict=False).as_posix()}"
+        else:
+            file_key = f"unresolved:{sub_path}"
+        return f"{file_key}|mode:{mode}|scale:{mesh_scale_key(scale)}"
+
+    def clean_mesh_name_part(value: str) -> str:
+        cleaned = re.sub(r"[^0-9A-Za-z_]+", "_", value).strip("_")
+        return cleaned or "mesh"
+
+    def preferred_mesh_name(filename: str, prefix: str = "", link_prefix: str = "") -> str:
+        name_parts = []
+        if link_prefix:
+            name_parts.append(clean_mesh_name_part(link_prefix))
+        if prefix:
+            name_parts.append(clean_mesh_name_part(prefix))
+        stem = clean_mesh_name_part(Path(filename).stem)
+        name_parts.append(stem)
+        return "_".join(name_parts)
+
+    def register_mesh_asset(filename: str, prefix: str = "", link_prefix: str = "", scale: str | None = None) -> str:
+        mode = prefix or "visual"
+        key = mesh_asset_key(filename, mode=mode, scale=scale)
+        existing_name = mesh_name_by_key.get(key)
+        if existing_name is not None:
+            return existing_name
+
+        base_name = preferred_mesh_name(filename, prefix=prefix, link_prefix=link_prefix)
+        mesh_name = base_name
+        existing_key = mesh_key_by_name.get(mesh_name)
+        if mesh_name in mesh_assets and existing_key != key:
+            suffix = hashlib.sha1(key.encode()).hexdigest()[:8]
+            mesh_name = f"{base_name}_{suffix}"
+            counter = 1
+            while mesh_name in mesh_assets and mesh_key_by_name.get(mesh_name) != key:
+                mesh_name = f"{base_name}_{suffix}_{counter}"
+                counter += 1
+
+        mesh_assets[mesh_name] = filename
+        mesh_key_by_name[mesh_name] = key
+        mesh_name_by_key[key] = mesh_name
+        return mesh_name
+
+    for existing_name, existing_filename in mesh_assets.items():
+        existing_key = mesh_asset_key(existing_filename, mode="existing", scale=None)
+        mesh_key_by_name[existing_name] = existing_key
+        mesh_name_by_key.setdefault(existing_key, existing_name)
 
     def handle_geom_element(
         geom_elem: ET.Element | None, default_size: str, prefix: str = "", link_prefix: str = ""
@@ -68,18 +141,13 @@ def build_robot_body_tree(
         if mesh_elem is not None:
             filename = mesh_elem.attrib.get("filename")
             if filename is not None:
-                mesh_name = Path(filename).stem
-                if prefix:
-                    mesh_name = f"{prefix}_{mesh_name}"
-                if link_prefix:
-                    mesh_name = f"{link_prefix}_{mesh_name}"
-                if mesh_name not in mesh_assets:
-                    mesh_assets[mesh_name] = filename
+                scale = mesh_elem.attrib.get("scale")
+                mesh_name = register_mesh_asset(filename, prefix=prefix, link_prefix=link_prefix, scale=scale)
 
                 return GeomElement(
                     type="mesh",
                     size=None,
-                    scale=mesh_elem.attrib.get("scale"),
+                    scale=scale,
                     mesh=mesh_name,
                 )
 
@@ -206,7 +274,7 @@ def build_robot_body_tree(
 
             collision_geom_elem = collision.find("geometry")
             if collision_geom_elem is not None:
-                geom = handle_geom_element(collision_geom_elem, "1 1 1", prefix="collision")
+                geom = handle_geom_element(collision_geom_elem, "1 1 1", prefix="collision", link_prefix=link_name)
                 collision_geom_attrib["type"] = geom.type
                 if geom.type == "mesh":
                     if geom.mesh is not None:

--- a/src/urdf_to_mjcf/conversion/pipeline.py
+++ b/src/urdf_to_mjcf/conversion/pipeline.py
@@ -30,7 +30,7 @@ from urdf_to_mjcf.conversion.mjcf_assembly import (
     add_visual,
 )
 from urdf_to_mjcf.core.geometry import ParsedJointParams
-from urdf_to_mjcf.core.model import ActuatorMetadata, ConversionMetadata, DefaultJointMetadata
+from urdf_to_mjcf.core.model import ActuatorMetadata, ConversionMetadata, DefaultJointMetadata, ExtraJoint
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +51,7 @@ class ConversionContext:
     root_link_name: str
     actuator_metadata: dict[str, ActuatorMetadata]
     mimic_constraints: list[tuple[str, str, float, float]]
+    metadata: ConversionMetadata
 
 
 def create_empty_actuator_metadata(robot_elem: ET.Element) -> dict[str, ActuatorMetadata]:
@@ -112,6 +113,7 @@ def build_conversion_context(
         root_link_name=root_link_name,
         actuator_metadata=resolved_actuator_metadata,
         mimic_constraints=mimic_constraints,
+        metadata=metadata,
     )
 
 
@@ -127,6 +129,66 @@ class SceneAssemblyResult:
     robot_body: ET.Element
     actuator_joints: list[ParsedJointParams]
     mesh_file_paths: dict[str, Path]
+
+
+def find_body(root: ET.Element, name: str) -> ET.Element | None:
+    """Find a body by name in a body subtree."""
+    if root.attrib.get("name") == name:
+        return root
+    for child in root.findall("body"):
+        match = find_body(child, name)
+        if match is not None:
+            return match
+    return None
+
+
+def add_extra_joints(
+    robot_body: ET.Element,
+    actuator_joints: list[ParsedJointParams],
+    extra_joints: list[ExtraJoint],
+) -> None:
+    """Inject MJCF-only joints into generated bodies."""
+    insert_indices: dict[str, int] = {}
+    touched_bodies: set[str] = set()
+
+    for joint in extra_joints:
+        body = find_body(robot_body, joint.body_name)
+        if body is None:
+            raise ValueError(f"Extra joint body not found: {joint.body_name}")
+
+        attrib = {
+            "name": joint.name,
+            "type": joint.type,
+            "axis": " ".join(str(value) for value in joint.axis),
+        }
+        lower = upper = None
+        if joint.joint_class is not None:
+            attrib["class"] = joint.joint_class
+        if joint.range is not None:
+            lower, upper = joint.range
+            attrib["range"] = f"{lower} {upper}"
+        insert_at = insert_indices.get(joint.body_name, 0)
+        body.insert(insert_at, ET.Element("joint", attrib=attrib))
+        insert_indices[joint.body_name] = insert_at + 1
+        touched_bodies.add(joint.body_name)
+        actuator_joints.append(ParsedJointParams(name=joint.name, type=joint.type, lower=lower, upper=upper))
+
+    for body_name in touched_bodies:
+        body = find_body(robot_body, body_name)
+        if body is not None and body.find("inertial") is None:
+            insert_at = insert_indices[body_name]
+            body.insert(insert_at, minimal_inertial())
+
+
+def minimal_inertial() -> ET.Element:
+    return ET.Element(
+        "inertial",
+        attrib={
+            "pos": "0 0 0",
+            "mass": "0.001",
+            "diaginertia": "1e-06 1e-06 1e-06",
+        },
+    )
 
 
 def assemble_robot_scene(
@@ -157,6 +219,7 @@ def assemble_robot_scene(
         urdf_dir=urdf_dir,
     )
     robot_body.attrib["childclass"] = ROBOT_CLASS
+    add_extra_joints(robot_body, actuator_joints, context.metadata.extra_joints)
     context.worldbody.append(robot_body)
 
     obj_materials = collect_single_obj_materials(

--- a/src/urdf_to_mjcf/core/geometry.py
+++ b/src/urdf_to_mjcf/core/geometry.py
@@ -137,7 +137,7 @@ def compute_min_z(
     body: ET.Element,
     parent_transform: list[list[float]] | None = None,
     mesh_file_paths: dict[str, Path] | None = None,
-    mesh_cache: dict[str, float] | None = None,
+    mesh_cache: dict[str, np.ndarray] | None = None,
 ) -> float:
     """Recursively computes the minimum Z value in the world frame.
 
@@ -147,7 +147,7 @@ def compute_min_z(
         body: The current body element.
         parent_transform: The transform of the parent body.
         mesh_file_paths: Dictionary mapping mesh names to their actual file paths.
-        mesh_cache: Cache for mesh min_z values to avoid reloading.
+        mesh_cache: Cache for mesh vertices to avoid reloading.
 
     Returns:
         The minimum Z value in the world frame.
@@ -174,39 +174,33 @@ def compute_min_z(
             geom_tf: list[list[float]] = build_transform(gpos_str, gquat_str)
             total_tf: list[list[float]] = mat_mult(body_tf, geom_tf)
 
-            # The translation part of T_total is in column 3.
-            z: float = total_tf[2][3]
             geom_type: str = child.attrib.get("type", "")
-            if geom_type == "box":
-                size_vals: list[float] = list(map(float, child.attrib.get("size", "0 0 0").split()))
-                half_height: float = size_vals[2] if len(size_vals) >= 3 else 0.0
-                candidate: float = z - half_height
-            elif geom_type == "cylinder":
-                size_vals = list(map(float, child.attrib.get("size", "0 0").split()))
-                half_length: float = size_vals[1] if len(size_vals) >= 2 else 0.0
-                candidate = z - half_length
-            elif geom_type == "sphere":
-                r = float(child.attrib.get("size", "0"))
-                candidate = z - r
+            if geom_type in {"box", "cylinder", "sphere", "capsule", "ellipsoid"}:
+                size_vals = list(map(float, child.attrib.get("size", "").split()))
+                candidate = _primitive_min_z(geom_type, size_vals, total_tf)
             elif geom_type == "mesh":
                 # Load mesh and compute actual min_z
                 mesh_name = child.attrib.get("mesh")
                 if mesh_name and mesh_file_paths and mesh_name in mesh_file_paths:
-                    if mesh_name not in mesh_cache:
+                    scale_str = child.attrib.get("scale")
+                    cache_key = f"{mesh_name}|{scale_str or ''}"
+                    if cache_key not in mesh_cache:
                         mesh_file_path = mesh_file_paths[mesh_name]
-                        mesh_min_z = _compute_mesh_min_z(mesh_file_path, child.attrib.get("scale"))
-                        mesh_cache[mesh_name] = mesh_min_z
-                    else:
-                        mesh_min_z = mesh_cache[mesh_name]
+                        mesh_cache[cache_key] = _load_mesh_vertices(mesh_file_path, scale_str)
 
-                    candidate = z + mesh_min_z
+                    vertices = mesh_cache[cache_key]
+                    if vertices.size:
+                        candidate = float(_transform_points(total_tf, vertices)[:, 2].min())
+                    else:
+                        candidate = float(np.asarray(total_tf, dtype=float)[2, 3])
                 else:
                     # Fallback to conservative estimate if mesh not available
+                    z = total_tf[2][3]
                     candidate = z - 0.2
                     if mesh_name:
                         logger.warning(f"Mesh {mesh_name} not found in mesh_file_paths, using fallback estimate")
             else:
-                candidate = z
+                candidate = total_tf[2][3]
 
             local_min_z = min(candidate, local_min_z)
 
@@ -217,33 +211,67 @@ def compute_min_z(
     return local_min_z
 
 
-def _compute_mesh_min_z(mesh_file_path: Path, scale_str: str | None = None) -> float:
-    """Compute the minimum Z value from a mesh file.
+def _transform_points(transform: list[list[float]], points: np.ndarray) -> np.ndarray:
+    """Apply a homogeneous transform to local 3D points."""
+    if points.size == 0:
+        return points
 
-    Args:
-        mesh_file_path: Full path to the mesh file.
-        scale_str: Optional scale string (e.g., "1 1 1").
+    transform_np = np.asarray(transform, dtype=float)
+    homogeneous = np.column_stack([points, np.ones(len(points))])
+    return (homogeneous @ transform_np.T)[:, :3]
 
-    Returns:
-        The minimum Z value in the mesh's local frame.
-    """
+
+def _primitive_min_z(geom_type: str, size_vals: list[float], total_tf: list[list[float]]) -> float:
+    """Compute world-frame minimum z for a MuJoCo primitive geom."""
+    transform_np = np.asarray(total_tf, dtype=float)
+    center_z = float(transform_np[2, 3])
+    z_row = transform_np[2, :3]
+
+    if geom_type == "box":
+        half_extents = np.array((size_vals + [0.0, 0.0, 0.0])[:3], dtype=float)
+        return center_z - float(np.dot(np.abs(z_row), half_extents))
+
+    if geom_type == "cylinder":
+        radius = size_vals[0] if len(size_vals) >= 1 else 0.0
+        half_length = size_vals[1] if len(size_vals) >= 2 else 0.0
+        radial_z = math.hypot(float(z_row[0]), float(z_row[1]))
+        axial_z = abs(float(z_row[2]))
+        return center_z - radius * radial_z - half_length * axial_z
+
+    if geom_type == "capsule":
+        radius = size_vals[0] if len(size_vals) >= 1 else 0.0
+        half_length = size_vals[1] if len(size_vals) >= 2 else 0.0
+        axial_z = abs(float(z_row[2]))
+        return center_z - radius - half_length * axial_z
+
+    if geom_type == "sphere":
+        radius = size_vals[0] if size_vals else 0.0
+        return center_z - radius
+
+    if geom_type == "ellipsoid":
+        radii = np.array((size_vals + [0.0, 0.0, 0.0])[:3], dtype=float)
+        return center_z - float(np.linalg.norm(z_row * radii))
+
+    return center_z
+
+
+def _load_mesh_vertices(mesh_file_path: Path, scale_str: str | None = None) -> np.ndarray:
+    """Load mesh vertices with optional scale applied."""
     try:
         import trimesh
     except ImportError:
         logger.warning("trimesh not available, using fallback for mesh min_z computation")
-        return -0.2
+        return np.empty((0, 3), dtype=float)
 
     if not mesh_file_path.exists():
         logger.warning(f"compute mesh z min: Mesh file not found: {mesh_file_path}")
-        return 0.0
+        return np.empty((0, 3), dtype=float)
 
     logger.info(f"Loading mesh file: {mesh_file_path}")
 
     try:
-        # Load the mesh
         mesh = trimesh.load(str(mesh_file_path), force="mesh")
 
-        # Handle scale if provided
         if scale_str:
             scale_vals = list(map(float, scale_str.split()))
             if len(scale_vals) == 3:
@@ -260,18 +288,34 @@ def _compute_mesh_min_z(mesh_file_path: Path, scale_str: str | None = None) -> f
             elif len(scale_vals) == 1:
                 mesh.apply_scale(scale_vals[0])
 
-        # Get minimum Z coordinate from vertices
         if hasattr(mesh, "vertices") and len(mesh.vertices) > 0:
-            min_z = float(mesh.vertices[:, 2].min())
-            logger.info(f"Computed min_z for mesh '{mesh_file_path.name}': {min_z}")
-            return min_z
-        else:
-            logger.warning(f"Mesh '{mesh_file_path.name}' has no vertices")
-            return 0.0
+            return np.asarray(mesh.vertices, dtype=float)
+
+        logger.warning(f"Mesh '{mesh_file_path.name}' has no vertices")
+        return np.empty((0, 3), dtype=float)
 
     except Exception as e:
         logger.warning(f"Failed to load mesh '{mesh_file_path.name}': {e}")
+        return np.empty((0, 3), dtype=float)
+
+
+def _compute_mesh_min_z(mesh_file_path: Path, scale_str: str | None = None) -> float:
+    """Compute the minimum Z value from a mesh file.
+
+    Args:
+        mesh_file_path: Full path to the mesh file.
+        scale_str: Optional scale string (e.g., "1 1 1").
+
+    Returns:
+        The minimum Z value in the mesh's local frame.
+    """
+    vertices = _load_mesh_vertices(mesh_file_path, scale_str)
+    if vertices.size == 0:
         return 0.0
+
+    min_z = float(vertices[:, 2].min())
+    logger.info(f"Computed min_z for mesh '{mesh_file_path.name}': {min_z}")
+    return min_z
 
 
 def rpy_to_quat(rpy_str: str) -> str:

--- a/src/urdf_to_mjcf/core/model.py
+++ b/src/urdf_to_mjcf/core/model.py
@@ -114,6 +114,15 @@ class ExplicitFloorContacts(BaseModel):
     class_name: str = "collision"
 
 
+class ExtraJoint(BaseModel):
+    body_name: str
+    name: str
+    type: Literal["slide", "hinge"]
+    axis: list[float]
+    joint_class: str | None = None
+    range: list[float] | None = None
+
+
 class WeldConstraint(BaseModel):
     """Represents a weld constraint between two bodies.
 
@@ -173,6 +182,7 @@ class ConversionMetadata(BaseModel):
     touch_sensors: list[TouchSensor] = []
     collision_geometries: list[CollisionGeometry] | None = None
     explicit_contacts: ExplicitFloorContacts | None = None
+    extra_joints: list[ExtraJoint] = []
     weld_constraints: list[WeldConstraint] = []
     remove_redundancies: bool = True
     maxhullvert: int | None = None

--- a/src/urdf_to_mjcf/postprocess/move_mesh_scale.py
+++ b/src/urdf_to_mjcf/postprocess/move_mesh_scale.py
@@ -1,22 +1,12 @@
 """Move scale attributes from geom elements to mesh asset definitions.
 
 This post-processing script handles the case where geom elements have scale
-attributes, which MuJoCo doesn't support directly. The scale is moved to the
-mesh asset definition in the <asset> section. When multiple geoms reference
-the same mesh file with different scales, new mesh entries are created.
-
-Example transformation:
-    Before:
-        <geom type="mesh" mesh="gripper.stl" scale="1 -1 1"/>
-        <geom type="mesh" mesh="gripper.stl"/>
-
-    After:
-        <geom type="mesh" mesh="gripper"/>
-        <geom type="mesh" mesh="gripper_1"/>
-
-        <mesh name="gripper" file="meshes/collision/gripper.stl"/>
-        <mesh name="gripper_1" file="meshes/collision/gripper.stl" scale="1 -1 1"/>
+attributes, which MuJoCo doesn't support directly. Positive scales are moved to
+the mesh asset definition. Negative scales are baked into generated mesh files so
+mirrored meshes keep correct face winding and lighting.
 """
+
+from __future__ import annotations
 
 import argparse
 import logging
@@ -24,9 +14,102 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Dict, Tuple
 
+import trimesh
+
 from urdf_to_mjcf.core.utils import save_xml
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_scale(scale_str: str) -> tuple[float, float, float] | None:
+    try:
+        values = tuple(float(value) for value in scale_str.split())
+    except ValueError:
+        return None
+
+    if len(values) == 1:
+        value = values[0]
+        return (value, value, value)
+    if len(values) == 3:
+        return values
+    return None
+
+
+def _format_number(value: float) -> str:
+    return f"{value:g}"
+
+
+def _format_scale(scale: tuple[float, float, float]) -> str:
+    return " ".join(_format_number(value) for value in scale)
+
+
+def _scale_token(scale: tuple[float, float, float]) -> str:
+    parts = []
+    for value in scale:
+        token = _format_number(value).replace("-", "m").replace(".", "p")
+        parts.append(token)
+    return "_".join(parts)
+
+
+def _is_identity_scale(scale: tuple[float, float, float]) -> bool:
+    return all(abs(value - 1.0) < 1e-12 for value in scale)
+
+
+def _has_negative_scale(scale: tuple[float, float, float]) -> bool:
+    return any(value < 0.0 for value in scale)
+
+
+def _mesh_root(mjcf_path: Path, root: ET.Element) -> Path:
+    compiler = root.find("compiler")
+    meshdir_ref = "." if compiler is None else compiler.attrib.get("meshdir", ".")
+    return (mjcf_path.parent / meshdir_ref).resolve()
+
+
+def _baked_mesh_relative_path(mesh_file: str, scale: tuple[float, float, float], mesh_root: Path) -> str | None:
+    mesh_path = (mesh_root / mesh_file).resolve()
+    if not mesh_path.exists():
+        logger.warning("Cannot bake scaled mesh; file does not exist: %s", mesh_path)
+        return None
+
+    baked_path = mesh_path.with_name(f"{mesh_path.stem}_scaled_{_scale_token(scale)}{mesh_path.suffix}")
+    if not baked_path.exists() or baked_path.stat().st_mtime < mesh_path.stat().st_mtime:
+        try:
+            loaded = trimesh.load(mesh_path, force="scene", process=False)
+            if isinstance(loaded, trimesh.Scene):
+                meshes = loaded.dump(concatenate=False)
+            else:
+                meshes = [loaded]
+
+            scaled_meshes = []
+            scale_matrix = [
+                [scale[0], 0.0, 0.0, 0.0],
+                [0.0, scale[1], 0.0, 0.0],
+                [0.0, 0.0, scale[2], 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+            for mesh in meshes:
+                if not isinstance(mesh, trimesh.Trimesh):
+                    continue
+                scaled = mesh.copy()
+                scaled.apply_transform(scale_matrix)
+                scaled_meshes.append(scaled)
+
+            if not scaled_meshes:
+                logger.warning("Cannot bake scaled mesh; no triangle geometry found in %s", mesh_path)
+                return None
+
+            if len(scaled_meshes) == 1:
+                scaled_meshes[0].export(baked_path)
+            else:
+                trimesh.util.concatenate(scaled_meshes).export(baked_path)
+        except Exception as exc:
+            logger.warning("Failed to bake scaled mesh %s with scale %s: %s", mesh_path, _format_scale(scale), exc)
+            return None
+
+    try:
+        return baked_path.relative_to(mesh_root).as_posix()
+    except ValueError:
+        return baked_path.as_posix()
 
 
 def move_mesh_scale(mjcf_path: str | Path) -> None:
@@ -45,6 +128,8 @@ def move_mesh_scale(mjcf_path: str | Path) -> None:
         logger.warning("No <asset> section found in MJCF file")
         return
 
+    mesh_root = _mesh_root(mjcf_path, root)
+
     # Build a mapping of mesh name -> mesh element and file path
     mesh_map: Dict[str, Tuple[ET.Element, str]] = {}
     for mesh_elem in asset.findall("mesh"):
@@ -54,7 +139,7 @@ def move_mesh_scale(mjcf_path: str | Path) -> None:
             mesh_map[mesh_name] = (mesh_elem, mesh_file)
 
     # Track mesh file + scale combinations to create unique mesh names
-    # Key: (original_mesh_name, scale_str), Value: new_mesh_name
+    # Key: (original_mesh_name, normalized_scale_str), Value: new_mesh_name
     scale_mesh_map: Dict[Tuple[str, str], str] = {}
 
     # Counter for generating unique mesh names
@@ -83,10 +168,16 @@ def move_mesh_scale(mjcf_path: str | Path) -> None:
                 logger.warning(f"Geom references non-existent mesh: {mesh_name}")
                 continue
 
+            parsed_scale = _parse_scale(scale_str)
+            if parsed_scale is None:
+                logger.warning("Invalid mesh scale '%s' on geom '%s'", scale_str, geom.attrib.get("name", "unnamed"))
+                continue
+            normalized_scale = _format_scale(parsed_scale)
+
             original_mesh_elem, mesh_file = mesh_map[mesh_name]
 
             # Create a key for this mesh+scale combination
-            key = (mesh_name, scale_str)
+            key = (mesh_name, normalized_scale)
 
             # Check if we already created a mesh for this combination
             if key in scale_mesh_map:
@@ -95,8 +186,10 @@ def move_mesh_scale(mjcf_path: str | Path) -> None:
             else:
                 # Check if the original mesh already has this scale
                 original_scale = original_mesh_elem.attrib.get("scale")
-                if original_scale == scale_str:
+                if original_scale == normalized_scale:
                     # The mesh already has this scale, just remove from geom
+                    new_mesh_name = mesh_name
+                elif _is_identity_scale(parsed_scale) and original_scale is None:
                     new_mesh_name = mesh_name
                 else:
                     # Need to create a new mesh entry
@@ -118,20 +211,33 @@ def move_mesh_scale(mjcf_path: str | Path) -> None:
 
                     mesh_counters[base_name] = counter + 1
 
+                    mesh_attrib = {"name": new_mesh_name, "file": mesh_file}
+                    if _has_negative_scale(parsed_scale):
+                        baked_file = _baked_mesh_relative_path(mesh_file, parsed_scale, mesh_root)
+                        if baked_file is not None:
+                            mesh_attrib["file"] = baked_file
+                        else:
+                            mesh_attrib["scale"] = normalized_scale
+                    else:
+                        mesh_attrib["scale"] = normalized_scale
+
                     # Create new mesh element in asset section
-                    new_mesh_elem = ET.Element(
-                        "mesh", attrib={"name": new_mesh_name, "file": mesh_file, "scale": scale_str}
-                    )
+                    new_mesh_elem = ET.Element("mesh", attrib=mesh_attrib)
 
                     # Insert after the original mesh
                     mesh_index = list(asset).index(original_mesh_elem)
                     asset.insert(mesh_index + 1, new_mesh_elem)
 
                     # Update tracking
-                    mesh_map[new_mesh_name] = (new_mesh_elem, mesh_file)
+                    mesh_map[new_mesh_name] = (new_mesh_elem, mesh_attrib["file"])
                     scale_mesh_map[key] = new_mesh_name
 
-                    logger.info(f"Created new mesh '{new_mesh_name}' with scale '{scale_str}' for file '{mesh_file}'")
+                    logger.info(
+                        "Created new mesh '%s' with scale '%s' for file '%s'",
+                        new_mesh_name,
+                        normalized_scale,
+                        mesh_file,
+                    )
 
             # Update geom to reference the new mesh and remove scale
             geom.attrib["mesh"] = new_mesh_name
@@ -149,7 +255,7 @@ def move_mesh_scale(mjcf_path: str | Path) -> None:
         if geom_type == "mesh" and mesh_name and "scale" not in geom.attrib:
             # Check if mesh name still has extension
             if mesh_name in mesh_map:
-                original_mesh_elem, mesh_file = mesh_map[mesh_name]
+                original_mesh_elem, _mesh_file = mesh_map[mesh_name]
 
                 # If the original mesh doesn't have a scale, normalize its name (remove extension)
                 if "scale" not in original_mesh_elem.attrib:

--- a/src/urdf_to_mjcf/postprocess/split_obj_materials.py
+++ b/src/urdf_to_mjcf/postprocess/split_obj_materials.py
@@ -17,6 +17,36 @@ from urdf_to_mjcf.postprocess.mesh_converter import dae2obj, glb2obj
 logger = logging.getLogger(__name__)
 
 
+def build_submesh_info(mesh_name: str, obj_file_path: Path, mesh_dir: Path) -> list[tuple[str, str]] | None:
+    """Build mesh asset names and relative paths for material-split OBJ files."""
+    obj_stem = obj_file_path.stem
+    split_dir = obj_file_path.parent / obj_stem
+    if not split_dir.exists():
+        return None
+
+    submeshes = list(split_dir.glob(f"{obj_stem}_*.obj"))
+    if not submeshes:
+        return None
+
+    link_prefix = ""
+    if mesh_name != obj_stem and obj_stem in mesh_name:
+        prefix_part = mesh_name[: mesh_name.rfind(obj_stem)]
+        if prefix_part.endswith("_"):
+            link_prefix = prefix_part[:-1]
+
+    submesh_info: list[tuple[str, str]] = []
+    for submesh_path in sorted(submeshes):
+        submesh_stem = submesh_path.stem
+        if link_prefix:
+            submesh_name = f"{link_prefix}_{submesh_stem}"
+        else:
+            submesh_name = submesh_stem
+        submesh_rel_path = submesh_path.relative_to(mesh_dir)
+        submesh_info.append((submesh_name, str(submesh_rel_path)))
+
+    return submesh_info
+
+
 def process_obj_materials(obj_file: Path, files_to_delete: list[Path] | None = None) -> dict[str, Material]:
     """Process MTL materials from OBJ file and split by materials.
 
@@ -72,12 +102,18 @@ def process_obj_materials(obj_file: Path, files_to_delete: list[Path] | None = N
             if sub_mtls:  # Only append if we have started a material
                 sub_mtls[-1].append(line)
 
-        # Skip processing if there's only one material
-        if len(sub_mtls) <= 1:
-            logger.info(f"OBJ file {obj_file.name} has only one material, skipping split processing")
+        # A single-material OBJ still needs its material registered in MJCF.
+        if len(sub_mtls) == 1:
+            material = Material.from_string(sub_mtls[0])
+            material.name = f"{obj_file.stem}_{material.name}"
+            materials[material.name] = material
+            logger.info(f"OBJ file {obj_file.name} has one material: {material.name}")
             mesh = trimesh.load_scene(obj_file)
             mesh.export(obj_file.as_posix(), mtl_name=mtl_file.name)
-            # Don't delete MTL here - it might be used by other OBJs
+            # Don't delete MTL here - it might be used by other OBJs.
+            return materials
+
+        if not sub_mtls:
             return materials
 
         # Process each material
@@ -308,10 +344,12 @@ def split_obj_by_materials(mjcf_path: str | Path) -> None:
         # Check if we've already processed this OBJ file
         if obj_file_path in processed_obj_files:
             logger.info(f"OBJ file {obj_file_path} already processed, reusing results")
-            obj_materials, split_info, single_material = processed_obj_files[obj_file_path]
+            obj_materials, cached_split_info, single_material = processed_obj_files[obj_file_path]
             all_mtl_materials.update(obj_materials)
-            if split_info is not None:
-                mesh_splits[mesh_name] = split_info
+            if cached_split_info is not None:
+                split_info = build_submesh_info(mesh_name, obj_file_path, mesh_dir)
+                if split_info is not None:
+                    mesh_splits[mesh_name] = split_info
             if single_material is not None:
                 mesh_single_materials[mesh_name] = single_material
             continue
@@ -321,42 +359,14 @@ def split_obj_by_materials(mjcf_path: str | Path) -> None:
         all_mtl_materials.update(obj_materials)
 
         # Check for split meshes in the same directory as the original OBJ file
-        obj_stem = obj_file_path.stem
-        split_dir = obj_file_path.parent / obj_stem
-
         split_info = None
         single_material = None
 
-        if split_dir.exists():
-            submeshes = list(split_dir.glob(f"{obj_stem}_*.obj"))
-            if submeshes:
-                # Found split meshes
-                submesh_info: list[tuple[str, str]] = []
-                # Extract link prefix from mesh_name if it exists
-                # mesh_name format: linkname_meshstem or just meshstem
-                link_prefix = ""
-                if mesh_name != obj_stem:
-                    # mesh_name has a prefix (link name)
-                    # Extract everything before the last occurrence of obj_stem
-                    if obj_stem in mesh_name:
-                        prefix_part = mesh_name[: mesh_name.rfind(obj_stem)]
-                        if prefix_part.endswith("_"):
-                            link_prefix = prefix_part[:-1]  # Remove trailing underscore
-
-                for i, submesh_path in enumerate(sorted(submeshes)):
-                    submesh_stem = submesh_path.stem
-                    # If mesh_name has a link prefix, add it to submesh name
-                    if link_prefix:
-                        submesh_name_with_prefix = f"{link_prefix}_{submesh_stem}"
-                    else:
-                        submesh_name_with_prefix = submesh_stem
-                    # Get relative path from mesh_dir
-                    submesh_rel_path = submesh_path.relative_to(mesh_dir)
-                    submesh_info.append((submesh_name_with_prefix, str(submesh_rel_path)))
-
-                mesh_splits[mesh_name] = submesh_info
-                split_info = submesh_info
-                logger.info(f"Found {len(submesh_info)} split meshes for {mesh_name}")
+        submesh_info = build_submesh_info(mesh_name, obj_file_path, mesh_dir)
+        if submesh_info is not None:
+            mesh_splits[mesh_name] = submesh_info
+            split_info = submesh_info
+            logger.info(f"Found {len(submesh_info)} split meshes for {mesh_name}")
 
         # Handle single mesh with multiple materials case
         # If obj_materials has content but no split meshes found, read actual material used in OBJ

--- a/tests/test_conversion_assets_and_builders.py
+++ b/tests/test_conversion_assets_and_builders.py
@@ -12,6 +12,7 @@ from urdf_to_mjcf.conversion.assets import (
     resolve_mesh_source_path,
     resolve_workspace_search_paths,
 )
+from urdf_to_mjcf.conversion.body_builder import build_robot_body_tree
 from urdf_to_mjcf.conversion.mjcf_assembly import (
     add_assets,
     add_compiler,
@@ -195,6 +196,80 @@ def test_add_mesh_assets_to_xml_normalizes_paths(tmp_path) -> None:
         "relative_mesh": "meshes/meshes/local.obj",
         "parent_relative_mesh": "meshes/meshes/umi_gripper/part.STL",
     }
+
+
+def test_build_robot_body_tree_uses_unique_mesh_assets_for_same_basename(tmp_path) -> None:
+    leg_mesh = write_text(tmp_path / "meshes" / "collision" / "leg" / "link1.stl", "solid leg\nendsolid leg\n")
+    arm_mesh = write_text(tmp_path / "meshes" / "collision" / "arm" / "link1.stl", "solid arm\nendsolid arm\n")
+    reused_leg_mesh = write_text(
+        tmp_path / "meshes" / "visual" / "leg" / "link1.stl",
+        "solid visual\nendsolid visual\n",
+    )
+
+    link_map = {
+        "base": ET.fromstring("<link name='base' />"),
+        "leg_link1": ET.fromstring(
+            f"""
+            <link name='leg_link1'>
+              <collision><geometry><mesh filename='{leg_mesh}' /></geometry></collision>
+              <visual><geometry><mesh filename='{reused_leg_mesh}' /></geometry></visual>
+            </link>
+            """
+        ),
+        "left_link1": ET.fromstring(
+            f"""
+            <link name='left_link1'>
+              <collision><geometry><mesh filename='{arm_mesh}' /></geometry></collision>
+              <visual><geometry><mesh filename='{arm_mesh}' /></geometry></visual>
+            </link>
+            """
+        ),
+        "right_link1": ET.fromstring(
+            f"""
+            <link name='right_link1'>
+              <collision><geometry><mesh filename='{arm_mesh}' scale='1 -1 1' /></geometry></collision>
+              <visual><geometry><mesh filename='{arm_mesh}' scale='1 -1 1' /></geometry></visual>
+            </link>
+            """
+        ),
+    }
+    parent_map = {
+        "base": [
+            ("leg_link1", ET.fromstring("<joint name='base_to_leg' type='fixed' />")),
+            ("left_link1", ET.fromstring("<joint name='base_to_arm' type='fixed' />")),
+            ("right_link1", ET.fromstring("<joint name='base_to_right_arm' type='fixed' />")),
+        ]
+    }
+    mesh_assets: dict[str, str] = {}
+
+    body, _ = build_robot_body_tree(
+        "base",
+        link_map=link_map,
+        parent_map=parent_map,
+        actuator_metadata={},
+        collision_only=False,
+        materials={},
+        mesh_assets=mesh_assets,
+        workspace_search_paths=[],
+        urdf_dir=tmp_path,
+    )
+
+    collision_mesh_refs = {
+        geom.attrib["name"]: geom.attrib["mesh"] for geom in body.findall(".//geom[@class='collision']")
+    }
+
+    assert collision_mesh_refs["leg_link1_collision"] != collision_mesh_refs["left_link1_collision"]
+    assert collision_mesh_refs["right_link1_collision"] != collision_mesh_refs["left_link1_collision"]
+    assert mesh_assets[collision_mesh_refs["leg_link1_collision"]] == str(leg_mesh)
+    assert mesh_assets[collision_mesh_refs["left_link1_collision"]] == str(arm_mesh)
+    assert mesh_assets[collision_mesh_refs["right_link1_collision"]] == str(arm_mesh)
+
+    left_visual = body.find(".//geom[@name='left_link1_visual']")
+    right_visual = body.find(".//geom[@name='right_link1_visual']")
+    assert left_visual is not None
+    assert right_visual is not None
+    assert left_visual.attrib["mesh"] != collision_mesh_refs["left_link1_collision"]
+    assert right_visual.attrib["mesh"] != left_visual.attrib["mesh"]
 
 
 def test_add_compiler_replaces_existing_element() -> None:

--- a/tests/test_conversion_scene.py
+++ b/tests/test_conversion_scene.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 
-from urdf_to_mjcf.conversion.pipeline import ConversionContext, assemble_robot_scene
+from urdf_to_mjcf.conversion.pipeline import ConversionContext, add_extra_joints, assemble_robot_scene
 from urdf_to_mjcf.core.geometry import ParsedJointParams
-from urdf_to_mjcf.core.model import ActuatorMetadata
+from urdf_to_mjcf.core.model import ActuatorMetadata, ConversionMetadata, ExtraJoint
 
 
 def test_assemble_robot_scene_orchestrates_body_assets_and_mesh_pipeline(tmp_path, monkeypatch) -> None:
@@ -21,6 +21,7 @@ def test_assemble_robot_scene_orchestrates_body_assets_and_mesh_pipeline(tmp_pat
         root_link_name="base",
         actuator_metadata={"joint1": ActuatorMetadata(actuator_type="motor")},
         mimic_constraints=[("joint0", "joint1", 1.0, 0.0)],
+        metadata=ConversionMetadata(),
     )
     robot_body = ET.Element("body", attrib={"name": "base"})
     actuator_joints = [ParsedJointParams(name="joint1", type="hinge")]
@@ -88,3 +89,51 @@ def test_assemble_robot_scene_orchestrates_body_assets_and_mesh_pipeline(tmp_pat
         ("mimic", [("joint0", "joint1", 1.0, 0.0)]),
         ("mesh_xml", {"mesh_a": "mesh_a.obj"}),
     ]
+
+
+def test_add_extra_joints_injects_joints_and_minimal_inertial() -> None:
+    robot_body = ET.fromstring('<body name="base"><body name="arm" /></body>')
+    actuator_joints: list[ParsedJointParams] = []
+    extra_joints = [
+        ExtraJoint(
+            body_name="base",
+            name="base_x",
+            type="slide",
+            axis=[1, 0, 0],
+            joint_class="base_slide",
+            range=[-1, 1],
+        ),
+        ExtraJoint(
+            body_name="base",
+            name="base_y",
+            type="slide",
+            axis=[0, 1, 0],
+            joint_class="base_slide",
+            range=[-2, 2],
+        ),
+        ExtraJoint(
+            body_name="base",
+            name="base_yaw",
+            type="hinge",
+            axis=[0, 0, 1],
+            joint_class="base_yaw",
+        ),
+    ]
+
+    add_extra_joints(robot_body, actuator_joints, extra_joints)
+
+    joints = robot_body.findall("joint")
+    assert [joint.attrib["name"] for joint in joints] == ["base_x", "base_y", "base_yaw"]
+    assert joints[0].attrib == {
+        "name": "base_x",
+        "type": "slide",
+        "axis": "1.0 0.0 0.0",
+        "class": "base_slide",
+        "range": "-1.0 1.0",
+    }
+    assert robot_body.find("inertial").attrib == {
+        "pos": "0 0 0",
+        "mass": "0.001",
+        "diaginertia": "1e-06 1e-06 1e-06",
+    }
+    assert [joint.name for joint in actuator_joints] == ["base_x", "base_y", "base_yaw"]

--- a/tests/test_conversion_scene.py
+++ b/tests/test_conversion_scene.py
@@ -131,7 +131,9 @@ def test_add_extra_joints_injects_joints_and_minimal_inertial() -> None:
         "class": "base_slide",
         "range": "-1.0 1.0",
     }
-    assert robot_body.find("inertial").attrib == {
+    inertial = robot_body.find("inertial")
+    assert inertial is not None
+    assert inertial.attrib == {
         "pos": "0 0 0",
         "mass": "0.001",
         "diaginertia": "1e-06 1e-06 1e-06",

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -51,7 +51,7 @@ EXPECTED_SIGNATURES: dict[str, dict[str, Any]] = {
             "body": 9,
             "geom": 38,
             "mesh": 34,
-            "material": 9,
+            "material": 8,
             "actuator": 8,
             "equality": 1,
         },

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,9 +1,11 @@
 """Tests for geometry utilities."""
 
 import math
+import xml.etree.ElementTree as ET
 
 from urdf_to_mjcf.core.geometry import (
     build_transform,
+    compute_min_z,
     format_value,
     parse_vector,
     quat_from_str,
@@ -41,6 +43,20 @@ def test_build_transform() -> None:
     assert t[1][3] == 2.0
     assert t[2][3] == 3.0
     assert t[3] == [0.0, 0.0, 0.0, 1.0]
+
+
+def test_compute_min_z_uses_rotated_cylinder_radius() -> None:
+    body = ET.fromstring(
+        """
+        <body>
+          <body pos="0 0 0.1">
+            <geom type="cylinder" size="0.105 0.025" quat="0.70710678 0 0.70710678 0"/>
+          </body>
+        </body>
+        """
+    )
+
+    assert abs(compute_min_z(body) - -0.005) < 1e-6
 
 
 def test_rpy_to_quat_zero() -> None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -37,12 +37,26 @@ def test_conversion_metadata_defaults() -> None:
     meta = ConversionMetadata()
     assert meta.freejoint is True
     assert meta.add_floor is True
+    assert meta.extra_joints == []
     assert len(meta.cameras) == 2
     assert meta.cameras[0].fovy == 90.0
 
 
 def test_conversion_metadata_json_roundtrip() -> None:
-    meta = ConversionMetadata(height_offset=0.5, angle="degree")
+    meta = ConversionMetadata(
+        height_offset=0.5,
+        angle="degree",
+        extra_joints=[
+            {
+                "body_name": "base_link",
+                "name": "base_x",
+                "type": "slide",
+                "axis": [1, 0, 0],
+                "joint_class": "base_slide",
+                "range": [-10, 10],
+            }
+        ],
+    )
     raw = meta.model_dump_json() if hasattr(meta, "model_dump_json") else meta.json()
     loaded = (
         ConversionMetadata.model_validate_json(raw)
@@ -51,6 +65,8 @@ def test_conversion_metadata_json_roundtrip() -> None:
     )
     assert loaded.height_offset == 0.5
     assert loaded.angle == "degree"
+    assert loaded.extra_joints[0].body_name == "base_link"
+    assert loaded.extra_joints[0].name == "base_x"
 
 
 def test_collision_geometry_enum() -> None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7,6 +7,7 @@ from urdf_to_mjcf.core.model import (
     CollisionType,
     ConversionMetadata,
     DefaultJointMetadata,
+    ExtraJoint,
 )
 
 
@@ -47,14 +48,14 @@ def test_conversion_metadata_json_roundtrip() -> None:
         height_offset=0.5,
         angle="degree",
         extra_joints=[
-            {
-                "body_name": "base_link",
-                "name": "base_x",
-                "type": "slide",
-                "axis": [1, 0, 0],
-                "joint_class": "base_slide",
-                "range": [-10, 10],
-            }
+            ExtraJoint(
+                body_name="base_link",
+                name="base_x",
+                type="slide",
+                axis=[1, 0, 0],
+                joint_class="base_slide",
+                range=[-10, 10],
+            )
         ],
     )
     raw = meta.model_dump_json() if hasattr(meta, "model_dump_json") else meta.json()

--- a/tests/test_postprocess_small_modules.py
+++ b/tests/test_postprocess_small_modules.py
@@ -251,8 +251,10 @@ def test_move_mesh_scale_bakes_negative_scale_mesh(tmp_path) -> None:
     assert mesh.attrib["file"] == "meshes/triangle_scaled_1_m1_1.obj"
 
     baked_mesh = trimesh.load(tmp_path / mesh.attrib["file"], force="mesh", process=False)
+    assert isinstance(baked_mesh, trimesh.Trimesh)
     assert baked_mesh.vertices.tolist() == [[0.0, -0.0, 0.0], [1.0, -0.0, 0.0], [0.0, -1.0, 0.0]]
     assert baked_mesh.face_normals[0].tolist() == [0.0, 0.0, 1.0]
+
 
 def test_split_obj_by_materials_rebuilds_submesh_names_for_reused_obj(tmp_path) -> None:
     mesh_path = write_text(tmp_path / "meshes" / "part.obj", "v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n")

--- a/tests/test_postprocess_small_modules.py
+++ b/tests/test_postprocess_small_modules.py
@@ -6,6 +6,8 @@ import math
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+import trimesh
+
 from urdf_to_mjcf.postprocess.base_joint import fix_base_joint
 from urdf_to_mjcf.postprocess.explicit_floor_contacts import add_explicit_floor_contacts
 from urdf_to_mjcf.postprocess.make_degrees import (
@@ -18,6 +20,8 @@ from urdf_to_mjcf.postprocess.make_degrees import (
     update_joint_limits,
     update_rpy_attributes,
 )
+from urdf_to_mjcf.postprocess.move_mesh_scale import move_mesh_scale
+from urdf_to_mjcf.postprocess.split_obj_materials import process_obj_materials, split_obj_by_materials
 
 
 def write_text(path: Path, content: str) -> Path:
@@ -181,3 +185,103 @@ def test_add_explicit_floor_contacts_creates_pairs_for_named_box_geoms(tmp_path)
         ("arm_box", "ground"),
         ("leg_box_a", "ground"),
     ]
+
+
+def test_process_obj_materials_registers_single_material_obj(tmp_path) -> None:
+    obj_path = write_text(
+        tmp_path / "link1.obj",
+        "\n".join(
+            [
+                "mtllib link1.mtl",
+                "usemtl metal_black",
+                "v 0 0 0",
+                "v 1 0 0",
+                "v 0 1 0",
+                "f 1 2 3",
+            ]
+        ),
+    )
+    write_text(obj_path.with_suffix(".mtl"), "newmtl metal_black\nKd 0.01 0.01 0.01\nd 1.0\n")
+
+    materials = process_obj_materials(obj_path)
+
+    assert list(materials) == ["link1_metal_black"]
+    assert materials["link1_metal_black"].mjcf_rgba() == "0.01 0.01 0.01 1.0"
+
+
+def test_move_mesh_scale_bakes_negative_scale_mesh(tmp_path) -> None:
+    mesh_path = write_text(
+        tmp_path / "meshes" / "triangle.obj",
+        "\n".join(
+            [
+                "v 0 0 0",
+                "v 1 0 0",
+                "v 0 1 0",
+                "f 1 2 3",
+            ]
+        ),
+    )
+    mjcf_path = write_text(
+        tmp_path / "model.xml",
+        f"""
+        <mujoco>
+          <compiler meshdir='.' />
+          <asset>
+            <mesh name='triangle' file='{mesh_path.relative_to(tmp_path).as_posix()}' />
+          </asset>
+          <worldbody>
+            <body name='body'>
+              <geom name='mirrored' type='mesh' mesh='triangle' scale='1 -1 1' />
+            </body>
+          </worldbody>
+        </mujoco>
+        """.strip(),
+    )
+
+    move_mesh_scale(mjcf_path)
+
+    root = ET.parse(mjcf_path).getroot()
+    geom = root.find(".//geom[@name='mirrored']")
+    assert geom is not None
+    assert "scale" not in geom.attrib
+
+    mesh = root.find(f"./asset/mesh[@name='{geom.attrib['mesh']}']")
+    assert mesh is not None
+    assert "scale" not in mesh.attrib
+    assert mesh.attrib["file"] == "meshes/triangle_scaled_1_m1_1.obj"
+
+    baked_mesh = trimesh.load(tmp_path / mesh.attrib["file"], force="mesh", process=False)
+    assert baked_mesh.vertices.tolist() == [[0.0, -0.0, 0.0], [1.0, -0.0, 0.0], [0.0, -1.0, 0.0]]
+    assert baked_mesh.face_normals[0].tolist() == [0.0, 0.0, 1.0]
+
+def test_split_obj_by_materials_rebuilds_submesh_names_for_reused_obj(tmp_path) -> None:
+    mesh_path = write_text(tmp_path / "meshes" / "part.obj", "v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n")
+    split_dir = mesh_path.parent / "part"
+    write_text(split_dir / "part_0.obj", "usemtl silver\nv 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n")
+    write_text(split_dir / "part_1.obj", "usemtl black\nv 0 0 0\nv 0 1 0\nv 0 0 1\nf 1 2 3\n")
+    mjcf_path = write_text(
+        tmp_path / "model.xml",
+        """
+        <mujoco>
+          <compiler meshdir='.' />
+          <asset>
+            <mesh name='left_part' file='meshes/part.obj' />
+            <mesh name='right_part' file='meshes/part.obj' />
+          </asset>
+          <worldbody>
+            <body name='body'>
+              <geom name='left_visual' class='visual' type='mesh' mesh='left_part' />
+              <geom name='right_visual' class='visual' type='mesh' mesh='right_part' />
+            </body>
+          </worldbody>
+        </mujoco>
+        """.strip(),
+    )
+
+    split_obj_by_materials(mjcf_path)
+
+    root = ET.parse(mjcf_path).getroot()
+    mesh_names = {mesh.attrib["name"] for mesh in root.findall("./asset/mesh")}
+    assert {"left_part_0", "left_part_1", "right_part_0", "right_part_1"} <= mesh_names
+    assert root.find(".//geom[@name='left_visual_0'][@mesh='left_part_0']") is not None
+    assert root.find(".//geom[@name='right_visual_0'][@mesh='right_part_0']") is not None


### PR DESCRIPTION
  This PR improves URDF-to-MJCF conversion in three areas:

  - Adds `extra_joints` metadata support for injecting MJCF-only `slide` / `hinge` joints into generated
bodies, with optional class and range metadata.
  - Makes mesh asset handling more robust by deduplicating meshes using resolved source path, usage mode,
and normalized scale instead of basename alone.
  - Fixes mesh/material post-processing edge cases, including negative mesh scales, reused OBJ references,
and single-material OBJ registration.
  - Fixes `min_z` computation for rotated primitives and meshes by evaluating bounds in world space.
  - Adds English and Chinese metadata docs plus focused regression tests.

  ## Motivation

  Some MJCF models need joints that do not exist in the source URDF, for example base slide joints or
simulator-only degrees of freedom. The new `extra_joints` metadata field makes that possible without editing
generated XML manually.

  The mesh changes address conversion failures or incorrect output when robots reuse mesh basenames, apply
different mesh scales, use mirrored meshes, or share OBJ files across multiple MJCF mesh assets.

  ## Testing

  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -p pytest_cov`
    - 97 passed
    - 1 failed: `tests/test_convert.py::test_convert_piper_basic`
    - Failure is a signature expectation mismatch: generated `agilex-piper` material count is `8`, while the
test currently expects `9`.